### PR TITLE
Accept iovec() as input for lz4f:compress_update/2

### DIFF
--- a/c_src/lz4_erlang.h
+++ b/c_src/lz4_erlang.h
@@ -26,6 +26,7 @@
 #define NIF_ATOMS(A) \
     A(ok) \
     A(done) \
+    A(continue) \
     A(enomem) \
     A(true) \
     A(false) \


### PR DESCRIPTION
iovec() is [binary()].

This also has the advantage of yielding in some cases. The implementation mirrors what is done for zlib.

cc @gerhard 