### PR TITLE
Use the `host_triple` library to load native code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ dep_lz4_src = git https://github.com/lz4/lz4 v1.9.2
 dep_nif_helpers = git https://github.com/ninenines/nif_helpers ead6adc15fca3c314351523080d2ccb1956d5956
 DEP_PLUGINS = nif_helpers
 
+DEPS = host_triple
+dep_host_triple = git https://github.com/rabbitmq/host_triple.git master
+
 C_SRC_OUTPUT = $(CURDIR)/priv/lz4_nif
 
 TEST_DEPS = ct_helper

--- a/ebin/lz4.app
+++ b/ebin/lz4.app
@@ -3,6 +3,6 @@
 	{vsn, "0.2.0"},
 	{modules, ['lz4_nif','lz4f']},
 	{registered, []},
-	{applications, [kernel,stdlib]},
+	{applications, [kernel,stdlib,host_triple]},
 	{env, []}
 ]}.

--- a/src/lz4_nif.erl
+++ b/src/lz4_nif.erl
@@ -25,14 +25,11 @@
 -export([lz4f_get_frame_info/2]).
 -export([lz4f_decompress/2]).
 
+-include_lib("host_triple/include/code_loading.hrl").
+
 -on_load(on_load/0).
 on_load() ->
-    case code:priv_dir(lz4) of
-        {error, _} ->
-            {error, {load_failed, "Could not determine the lz4-erlang priv/ directory."}};
-        Path ->
-            erlang:load_nif(filename:join(Path, atom_to_list(?MODULE)), 0)
-    end.
+    ?load_nif_from_host_triple_dir(lz4, atom_to_list(?MODULE), 0).
 
 %% lz4f.
 


### PR DESCRIPTION
This allows to have one copy of the `lz4_nif` native library per supported platform. The layout would look like:

```
priv
+-- x86_64-pc-windows-msvc
|   `-- lz4_nif.dll
+-- x86_64-unknown-freebsd13.0
|   `-- lz4_nif.so
`-- x86_64-unknown-linux-gnu
    `-- lz4_nif.so
```

The code still tries to load `priv/lz4_nif.*`, but the platform-specific directory has precedence. To sum up, paths are tried in the following order:
  1. `priv/$host_triple/lz4_nif.*`
  2. `priv/lz4_nif.*`

It stops right after the first successful load.

Fixes #5.
[#170523036]