### PR TITLE
Fix infinite loop when decode data with broken lz4 header

### DIFF
--- a/c_src/lz4f.c
+++ b/c_src/lz4f.c
@@ -333,7 +333,7 @@ NIF_FUNCTION(lz4f_decompress)
 {
     void* dctx_res;
     ERL_NIF_TERM head, reversed;
-    size_t dstSize, srcRead, srcSize;
+    size_t dstSize, srcRead, srcSize, result;
     ErlNifBinary srcBin, dstBin;
 
     BADARG_IF(!enif_get_resource(env, argv[0], res_LZ4F_dctx, &dctx_res));
@@ -351,14 +351,14 @@ NIF_FUNCTION(lz4f_decompress)
             return enif_raise_exception(env, atom_enomem);
         }
 
-        LZ4F_decompress(NIF_RES_GET(LZ4F_dctx, dctx_res),
+        result = LZ4F_decompress(NIF_RES_GET(LZ4F_dctx, dctx_res),
             dstBin.data, &dstSize,
             srcBin.data + srcRead, &srcSize,
             NULL);
 
-        if (LZ4F_isError(dstSize)) {
+        if (LZ4F_isError(result)) {
             enif_release_binary(&dstBin);
-            return enif_raise_exception(env, atom_enomem);
+            return enif_raise_exception(env, enif_make_atom(env, LZ4F_getErrorName(result)));
         }
 
         if (!enif_realloc_binary(&dstBin, dstSize)) {


### PR DESCRIPTION
we need check result LZ4F_decompress, not dstSize, because it always 0, when lz4 data/header is broken and it generates infinite cycle with reallocs memory