### PR TITLE
Rework nif compilation to avoid explicit paths

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,7 +2,6 @@ load("@rules_erlang//:erlang_app.bzl", "erlang_app", "test_erlang_app")
 load("@rules_erlang//:xref2.bzl", "xref")
 load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load("@rules_erlang//:ct.bzl", "assert_suites", "ct_suite")
-load("@rules_erlang//tools:erlang_headers.bzl", "DEFAULT_FILENAMES")
 load(":util.bzl", "common_root_as_var")
 
 APP_NAME = "lz4"
@@ -15,28 +14,11 @@ DEPS = [
     "@host_triple//:erlang_app",
 ]
 
-# NOTE: A combination of genrule and cc_import is used to copy headers
-#       such that they can be included at a known relative path when
-#       building :lz4_nif_linux.
-
-# places files in $(BINDIR) for inclusion at a known path below
-genrule(
-    name = "erlang_headers_files",
-    srcs = [
-        "@rules_erlang//tools:erlang_headers",
-    ],
-    outs = DEFAULT_FILENAMES,
-    cmd = "cp $(SRCS) $(RULEDIR)",
-)
-
-cc_import(
-    name = "erlang_headers",
-    hdrs = [
-        ":erlang_headers_files",
-    ],
-)
-
-# places files in $(BINDIR) for inclusion at a known path below
+# NOTE: lz4 headers are referenced with <> paths in c_src, so they
+#       need to be supplied in the deps to :lz4_nif_linux. This
+#       means cc_import must be used, and because cc_import does not
+#       appear to relative-ize any paths, we use genrule to place
+#       the files appropriately
 genrule(
     name = "liblz4_files",
     srcs = [
@@ -61,37 +43,22 @@ cc_import(
     static_library = ":liblz4.a",
 )
 
-# places files in $(BINDIR) for inclusion at a known path below
-genrule(
-    name = "nif_helpers_files",
+common_root_as_var(
+    name = "erlang_headers_dir",
     srcs = [
-        "@nif_helpers//:nif_helpers.h",
-        "@nif_helpers//:nif_helpers.c",
-    ],
-    outs = [
-        "nif_helpers.h",
-        "nif_helpers.c",
-    ],
-    cmd = "cp $(SRCS) $(RULEDIR)",
-)
-
-cc_library(
-    name = "nif_helpers",
-    srcs = [
-        "nif_helpers.c",
-        "nif_helpers.h",
         "@rules_erlang//tools:erlang_headers",
-    ],
-    hdrs = [
-        "nif_helpers.h",
-    ],
-    deps = [
-        ":erlang_headers",
     ],
 )
 
 common_root_as_var(
-    name = "lz4_headers_root",
+    name = "nif_helpers_dir",
+    srcs = [
+        "@nif_helpers//:nif_helpers.h",
+    ],
+)
+
+common_root_as_var(
+    name = "lz4_headers_dir",
     srcs = [
         ":liblz4_files",
     ],
@@ -102,9 +69,15 @@ cc_binary(
     srcs = glob([
         "c_src/**/*.c",
         "c_src/**/*.h",
-    ]),
+    ]) + [
+        "@rules_erlang//tools:erlang_headers",
+        "@nif_helpers//:nif_helpers.h",
+        "@nif_helpers//:nif_helpers.c",
+    ],
     copts = [
-        "-I $(LZ4_HEADERS_ROOT)",
+        "-I $(ERLANG_HEADERS_DIR)",
+        "-I $(NIF_HELPERS_DIR)",
+        "-I $(LZ4_HEADERS_DIR)",
         "-fPIC",
         # "-Wno-implicit-function-declaration",
         # "-Wno-unused-command-line-argument",
@@ -121,12 +94,12 @@ cc_binary(
         "@bazel_tools//platforms:linux",
     ],
     toolchains = [
-        ":lz4_headers_root",
+        ":erlang_headers_dir",
+        ":nif_helpers_dir",
+        ":lz4_headers_dir",
     ],
     deps = [
-        ":erlang_headers",
         ":liblz4",
-        ":nif_helpers",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_erlang//:xref2.bzl", "xref")
 load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load("@rules_erlang//:ct.bzl", "assert_suites", "ct_suite")
 load("@rules_erlang//tools:erlang_headers.bzl", "DEFAULT_FILENAMES")
+load(":util.bzl", "common_root_as_var")
 
 APP_NAME = "lz4"
 
@@ -89,6 +90,13 @@ cc_library(
     ],
 )
 
+common_root_as_var(
+    name = "lz4_headers_root",
+    srcs = [
+        ":liblz4_files",
+    ],
+)
+
 cc_binary(
     name = "lz4_nif_linux",
     srcs = glob([
@@ -96,7 +104,7 @@ cc_binary(
         "c_src/**/*.h",
     ]),
     copts = [
-        "-I $(BINDIR)",
+        "-I $(LZ4_HEADERS_ROOT)",
         "-fPIC",
         # "-Wno-implicit-function-declaration",
         # "-Wno-unused-command-line-argument",
@@ -111,6 +119,9 @@ cc_binary(
     target_compatible_with = [
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
+    ],
+    toolchains = [
+        ":lz4_headers_root",
     ],
     deps = [
         ":erlang_headers",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_erlang//:erlang_app.bzl", "erlang_app", "test_erlang_app")
 load("@rules_erlang//:xref2.bzl", "xref")
 load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load("@rules_erlang//:ct.bzl", "assert_suites", "ct_suite")
+load("@rules_erlang//tools:erlang_headers.bzl", "DEFAULT_FILENAMES")
 
 APP_NAME = "lz4"
 
@@ -13,23 +14,89 @@ DEPS = [
     "@host_triple//:erlang_app",
 ]
 
+# NOTE: A combination of genrule and cc_import is used to copy headers
+#       such that they can be included at a known relative path when
+#       building :lz4_nif_linux.
+
+# places files in $(BINDIR) for inclusion at a known path below
+genrule(
+    name = "erlang_headers_files",
+    srcs = [
+        "@rules_erlang//tools:erlang_headers",
+    ],
+    outs = DEFAULT_FILENAMES,
+    cmd = "cp $(SRCS) $(RULEDIR)",
+)
+
+cc_import(
+    name = "erlang_headers",
+    hdrs = [
+        ":erlang_headers_files",
+    ],
+)
+
+# places files in $(BINDIR) for inclusion at a known path below
+genrule(
+    name = "liblz4_files",
+    srcs = [
+        "@lz4_src//:lib/lz4.h",
+        "@lz4_src//:lib/lz4frame.h",
+        "@lz4_src//:static_library_linux",
+    ],
+    outs = [
+        "lz4.h",
+        "lz4frame.h",
+        "liblz4.a",
+    ],
+    cmd = "cp $(SRCS) $(RULEDIR)",
+)
+
+cc_import(
+    name = "liblz4",
+    hdrs = [
+        ":lz4.h",
+        ":lz4frame.h",
+    ],
+    static_library = ":liblz4.a",
+)
+
+# places files in $(BINDIR) for inclusion at a known path below
+genrule(
+    name = "nif_helpers_files",
+    srcs = [
+        "@nif_helpers//:nif_helpers.h",
+        "@nif_helpers//:nif_helpers.c",
+    ],
+    outs = [
+        "nif_helpers.h",
+        "nif_helpers.c",
+    ],
+    cmd = "cp $(SRCS) $(RULEDIR)",
+)
+
+cc_library(
+    name = "nif_helpers",
+    srcs = [
+        "nif_helpers.c",
+        "nif_helpers.h",
+        "@rules_erlang//tools:erlang_headers",
+    ],
+    hdrs = [
+        "nif_helpers.h",
+    ],
+    deps = [
+        ":erlang_headers",
+    ],
+)
+
 cc_binary(
     name = "lz4_nif_linux",
     srcs = glob([
         "c_src/**/*.c",
         "c_src/**/*.h",
-    ]) + [
-        "@rules_erlang//tools:erlang_headers",
-        "@lz4_src//:lib/lz4.h",
-        "@lz4_src//:lib/lz4frame.h",
-        "@lz4_src//:static_library_linux",
-        "@nif_helpers//:nif_helpers.h",
-        "@nif_helpers//:nif_helpers.c",
-    ],
+    ]),
     copts = [
-        "-I $(BINDIR)/external/rules_erlang.3.2.0/tools/erlang_headers",
-        "-I external/.external_deps.lz4_src/lib",
-        "-I external/.external_deps.nif_helpers",
+        "-I $(BINDIR)",
         "-fPIC",
         # "-Wno-implicit-function-declaration",
         # "-Wno-unused-command-line-argument",
@@ -44,6 +111,11 @@ cc_binary(
     target_compatible_with = [
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
+    ],
+    deps = [
+        ":erlang_headers",
+        ":liblz4",
+        ":nif_helpers",
     ],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ use_repo(
 
 bazel_dep(
     name = "rules_erlang",
-    version = "3.2.0",
+    version = "3.3.0",
 )
 
 erlang_package = use_extension(

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -33,7 +33,7 @@ generlang(
     outs = [
         "lib/liblz4.a",
     ],
-    cmd = "make -C external/.external_deps.lz4_src/lib && cp external/.external_deps.lz4_src/lib/liblz4.a $@",
+    cmd = "LIB_DIR=$(dirname $(location lib/Makefile)); make -C $LIB_DIR && cp $LIB_DIR/liblz4.a $@",
     exec_compatible_with = [
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",

--- a/util.bzl
+++ b/util.bzl
@@ -1,0 +1,33 @@
+def _common_root_as_var(ctx):
+    if ctx.attr.var_name != "":
+        key = ctx.attr.var_name
+    else:
+        key = ctx.label.name.upper()
+
+    value = ctx.files.srcs[0].dirname
+    for src in ctx.files.srcs:
+        if value.startswith(src.dirname):
+            value = src.dirname
+        elif src.dirname.startswith(value):
+            pass
+        elif value == src.dirname:
+            pass
+        else:
+            fail("%s and %s do not share a common root" % (value, src.dirname))
+
+    return [
+        platform_common.TemplateVariableInfo({
+            key: value,
+        }),
+    ]
+
+common_root_as_var = rule(
+    implementation = _common_root_as_var,
+    attrs = {
+        "var_name": attr.string(),
+        "srcs": attr.label_list(
+            allow_files = True,
+            mandatory = True,
+        ),
+    },
+)


### PR DESCRIPTION
These paths were not sufficiently consistent across different builds to be reliable

Requires and updated `rules_erlang` with https://github.com/rabbitmq/rules_erlang/pull/58 merged