### PR TITLE
Fetch deps from rabbitmq/bazel-central-registry:erlang-packages

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,6 @@
 build --experimental_enable_bzlmod
-build --registry=https://raw.githubusercontent.com/rabbitmq/bazel-central-registry/dev/
+build --registry=https://bcr.bazel.build/
+build --registry=https://raw.githubusercontent.com/rabbitmq/bazel-central-registry/erlang-packages/
 
 build --incompatible_strict_action_env
 build --local_test_jobs=1

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "lz4",
-    version = "1.9.2.3",
+    version = "2022.10.21",
 )
 
 external_deps = use_extension(
@@ -17,7 +17,7 @@ use_repo(
 
 bazel_dep(
     name = "rules_erlang",
-    version = "3.8.1",
+    version = "3.8.3",
 )
 
 erlang_config_extension = use_extension(
@@ -43,24 +43,13 @@ use_repo(
     "erlang_config",
 )
 
-erlang_package = use_extension(
-    "@rules_erlang//bzlmod:extensions.bzl",
-    "erlang_package",
-)
-
-erlang_package.hex_package(
+bazel_dep(
     name = "host_triple",
-    sha256 = "26fee396a7c0e1d66115e74638a795366496b59bf13f474f3ae1c4491fd14fc5",
     version = "0.1.0",
 )
 
-erlang_package.git_package(
-    branch = "master",
-    repository = "extend/ct_helper",
-)
-
-use_repo(
-    erlang_package,
-    "host_triple",
-    "ct_helper",
+bazel_dep(
+    name = "ct_helper",
+    version = "2022.10.21",
+    dev_dependency = True,
 )


### PR DESCRIPTION
Fetch dependencies from the rabbitmq erlang-packages bzlmod registry

https://github.com/rabbitmq/bazel-central-registry/tree/erlang-packages