### PR TITLE
Always use -fPIC when compiling liblz4.a with bazel

### DIFF
--- a/extensions.bzl
+++ b/extensions.bzl
@@ -33,7 +33,7 @@ generlang(
     outs = [
         "lib/liblz4.a",
     ],
-    cmd = "LIB_DIR=$(dirname $(location lib/Makefile)); make -C $LIB_DIR && cp $LIB_DIR/liblz4.a $@",
+    cmd = "LIB_DIR=$(dirname $(location lib/Makefile)); make -C $LIB_DIR liblz4.a MOREFLAGS=-fPIC && cp $LIB_DIR/liblz4.a $@",
     visibility = ["//visibility:public"],
 )
 """


### PR DESCRIPTION
Seems to be necessary in some environments when that code ends up in the final dynamic lib that is the erlang nif