### PR TITLE
Mark ct_helper as a test dep in bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ use_repo(
 
 bazel_dep(
     name = "rules_erlang",
-    version = "3.8.5",
+    version = "3.9.11",
 )
 
 erlang_config_extension = use_extension(
@@ -59,13 +59,24 @@ erlang_package.hex_package(
     version = "0.1.0",
 )
 
-erlang_package.git_package(
+use_repo(
+    erlang_package,
+    "host_triple",
+)
+
+erlang_dev_package = use_extension(
+    "@rules_erlang//bzlmod:extensions.bzl",
+    "erlang_package",
+    dev_dependency = True,
+)
+
+erlang_dev_package.git_package(
+    testonly = True,
     branch = "master",
     repository = "extend/ct_helper",
 )
 
 use_repo(
-    erlang_package,
-    "host_triple",
+    erlang_dev_package,
     "ct_helper",
 )


### PR DESCRIPTION
so that modules depending on lz4-erlang do not need to have a matching version of it

Also upgrades rules_erlang to the latest version