### PR TITLE
Move the PDF download used for tests to it's own bzlmod extension

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,6 +17,16 @@ use_repo(
     external_deps,
     "lz4_src",
     "nif_helpers",
+)
+
+external_test_deps = use_extension(
+    ":extensions.bzl",
+    "external_test_deps",
+    dev_dependency = True,
+)
+
+use_repo(
+    external_test_deps,
     "pdf_reference",
 )
 

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -60,12 +60,17 @@ def _external_deps(_ctx):
         remote = "https://github.com/ninenines/nif_helpers",
     )
 
+external_deps = module_extension(
+    implementation = _external_deps,
+)
+
+def _external_test_deps(_ctx):
     maybe(
         repo_rule = http_file,
         name = "pdf_reference",
         urls = ["https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.7old.pdf"],
     )
 
-external_deps = module_extension(
-    implementation = _external_deps,
+external_test_deps = module_extension(
+    implementation = _external_test_deps,
 )


### PR DESCRIPTION
that is marked as a dev_dependency and therefore not inherited by modules depending on this module