### PR TITLE
Drop OTP 24 from test matrix

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,9 +40,6 @@ build:rbe --host_platform=//platforms:erlang_internal_platform
 build:rbe --host_cpu=k8
 build:rbe --cpu=k8
 
-build:rbe-24 --config=rbe
-build:rbe-24 --platforms=//platforms:erlang_linux_24_platform
-
 build:rbe-25 --config=rbe
 build:rbe-25 --platforms=//platforms:erlang_linux_25_platform
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,6 @@ jobs:
       fail-fast: false
       matrix:
         bazel_otp_name:
-        - "24"
         - "25"
         - "26"
     steps:

--- a/.github/workflows/update-otp-patches.yaml
+++ b/.github/workflows/update-otp-patches.yaml
@@ -16,12 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         erlang_version:
-        - "24.3"
         - "25.3"
         - "26.0"
         include:
-        - erlang_version: "24.3"
-          name: '24'
         - erlang_version: "25.3"
           name: '25'
         - erlang_version: "26.0"

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -7,14 +7,6 @@ platform(
 )
 
 platform(
-    name = "erlang_linux_24_platform",
-    constraint_values = [
-        "@erlang_config//:erlang_24",
-    ],
-    parents = ["@rbe//config:platform"],
-)
-
-platform(
     name = "erlang_linux_25_platform",
     constraint_values = [
         "@erlang_config//:erlang_25",


### PR DESCRIPTION
It's been ~3 years since the initial 24.x release